### PR TITLE
change creation_date to ISO-8601 format

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -30,7 +30,7 @@ class ResourceMetadata:
         return {
             "uuid": str(self.uuid),
             "file_name": self.file_name,
-            "creation_date": date.strftime(self.creation_date, "%d.%m.%Y"),
+            "creation_date": self.creation_date.isoformat(),
             "unlock_date": self.unlock_date.isoformat(),
             "title": self.title,
             "caption": self.caption,


### PR DESCRIPTION
Changes the property `creation_date` to be stored as ISO-8601 format internally.  
This not only adjusts to the other property `unlock_date`, which is also in this format, but also allows the frontend to easily convert the date in whatever format it's required.