### PR TITLE
add endpoint to retrieve single resource metadata

### DIFF
--- a/blueprints.py
+++ b/blueprints.py
@@ -23,6 +23,7 @@ from database import (
     get_all_resources,
     get_resource_file,
     get_resource_metadata,
+    get_resource_metadata_json,
     store_file,
     update_resource_metadata,
     upload_resource_metadata,
@@ -38,6 +39,19 @@ blueprint_backend = Blueprint("backend", __name__)
 @blueprint_backend.route("/", methods=["GET"])
 def blueprint_get_all_available_resources():
     return get_all_resources()
+
+
+@blueprint_backend.route("/meta", methods=["GET"])
+def blueprint_get_resource_meta(uuid=None):
+    if not uuid:
+        uuid = request.args["uuid"]
+    if not uuid:
+        raise ValueError("Please provide the uuid.")
+    meta = get_resource_metadata_json(uuid)
+    if not meta:
+        raise FileNotFoundError(f"The meta with uuid {uuid} does not exist.")
+
+    return meta
 
 
 @blueprint_backend.route("/resource", methods=["GET"])

--- a/database.py
+++ b/database.py
@@ -57,6 +57,15 @@ def get_resource_metadata(uuid: str):
         return result
 
 
+def get_resource_metadata_json(uuid: str):
+    query = {"uuid": uuid}
+    result = db["resource_metadata"].find_one(query)
+    json_res = parse_json(result)
+    del json_res["_id"]
+    
+    return json_res
+
+
 def update_resource_metadata(
     uuid: str, title: str, caption: str, uploaded_by: str, creation_date: date
 ):


### PR DESCRIPTION
adds new endpoint `/meta` to retrieve a single meta resource file.

- REST-Method: `GET`
- Params:  `{uuid: str}`
- Returns: `ResourceMetadata`

Example: 
```bash
 curl 'localhost:8000/meta?uuid=982de682-83ad-11ee-aeae-0242ac150003'
```
```json
{
  "caption":"caption 000",
  "creation_date":"2023-11-08",
  "file_name":"0.png",
  "title":"Cat 0",
  "unlock_date":"2024-11-07",
  "uploaded_by":"Jakob",
  "uuid":"982de682-83ad-11ee-aeae-0242ac150003"
}
```
